### PR TITLE
Redesign the Ubuntu MATE GRUB Theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ grub2-themes-ubuntu-mate
 Except where otherwise **noted**, content of grub2-themes-ubuntu-mate by Ivan Pejić aka nadrimajstor is licensed under a [Creative Commons Attribution-ShareAlike 4.0 International License](http://creativecommons.org/licenses/by-sa/4.0/)
 ***
 
+[See the redesigned Ubuntu MATE GRUB Theme](https://github.com/RobLoach/ubuntu-mate)
+
 ![final](docs/final.png)
 
 ###Debian package install


### PR DESCRIPTION
This isn't really a pull request, but a question about if there's interest in moving this over to this repository to get more community traction.

I redesigned the [Ubuntu MATE GRUB Theme](https://github.com/RobLoach/ubuntu-mate) to match the design of Ubuntu MATE 18.04...

[![Ubuntu MATE GRUB Theme Screenshot](https://github.com/RobLoach/ubuntu-mate/raw/master/screenshot.png)](https://github.com/RobLoach/ubuntu-mate)

Was wondering if there was any interest in pushing this to the /ubuntu-mate community/org. I love having it match the login screen design. If you like it, feel free to let me know, and I'll make a new pull request to push it forwards! Thanks.

https://github.com/RobLoach/ubuntu-mate